### PR TITLE
Save aligned consensus

### DIFF
--- a/scripts/frameshift_deletions_checks
+++ b/scripts/frameshift_deletions_checks
@@ -213,8 +213,8 @@ def align(reference, consensus):
         (will appear as deletions *in the reference*)
     """
 
-
     all_align=[]
+    align_casepreserved=[]
 
     # Loop through pairs to avoid MAFFT aligning different unrelated segments
     for seq_record, ref_record in zip(SeqIO.parse(consensus, "fasta"), SeqIO.parse(reference, "fasta")):
@@ -247,6 +247,18 @@ def align(reference, consensus):
                 print(mafft_cline, ":", file=sys.stderr)
                 print(stderr, file=sys.stderr)
             all_align += AlignIO.read(StringIO(stdout), "fasta")
+
+        # We need to save the aligned consensus, but we need to preserve the nucleotide letter case
+        # Workaround: tempfiles are not visibile by os.system, BUT --preservecase is not implemented in MafftCommandline. Working with an explicit temp file saved in folder
+        with open ("tmp.fasta", "w") as f:
+            SeqIO.write(data, f, "fasta")
+        os.system("mafft --preservecase tmp.fasta 1> temp_out.fasta")
+        align_casepreserved += AlignIO.read("temp_out.fasta", "fasta")
+        os.system("rm tmp.fasta temp_out.fasta")
+
+    # Write the aligned fasta consensus to disk in the same position as the original unaligned input consensus
+    # all_align will always have the structure: [reference, seq, ...], so we need to slice only the elements at odd indexes
+    SeqIO.write(align_casepreserved[1::2], consensus.replace(".fasta", "_aligned.fasta"), "fasta")
 
     return all_align
 # static re: only compile it once

--- a/scripts/frameshift_deletions_checks
+++ b/scripts/frameshift_deletions_checks
@@ -249,12 +249,15 @@ def align(reference, consensus):
             all_align += AlignIO.read(StringIO(stdout), "fasta")
 
         # We need to save the aligned consensus, but we need to preserve the nucleotide letter case
-        # Workaround: tempfiles are not visibile by os.system, BUT --preservecase is not implemented in MafftCommandline. Working with an explicit temp file saved in folder
-        with open ("tmp.fasta", "w") as f:
-            SeqIO.write(data, f, "fasta")
-        os.system("mafft --preservecase tmp.fasta 1> temp_out.fasta")
-        align_casepreserved += AlignIO.read("temp_out.fasta", "fasta")
-        os.system("rm tmp.fasta temp_out.fasta")
+        # In order to preserve the possible case-sensitivity of downstream steps, the consensus is saved by running MAFFT one more time
+        with tempfile.NamedTemporaryFile() as tmp:
+            with open(tmp.name, 'w') as f:
+                SeqIO.write(data, tmp.name, "fasta")
+                f.seek(0)
+            with tempfile.NamedTemporaryFile() as tmp2:
+                with open(tmp2.name, 'w') as f2:
+                    os.system("mafft --preservecase " + tmp.name + " 1> " + tmp2.name)
+                align_casepreserved += AlignIO.read(tmp2.name, "fasta")
 
     # Write the aligned fasta consensus to disk in the same position as the original unaligned input consensus
     # all_align will always have the structure: [reference, seq, ...], so we need to slice only the elements at odd indexes


### PR DESCRIPTION
The complete migration of the S3C project towards using the consensus sequences generated by bcftools requires to have a fasta file on disk with the consensus sequenced aligned to the reference.
At present, only the unaligned sequence is available in the `references` folder of a sample.

The step is added to the script `frameshift_deletions_checks` because it is already performing the alignment.

Caveats and points of discussion:
We want to maintain the letter case in the final aligned sequence, in order to be able to mask ambiguous nucleotides if needed (although at the date of writing bcftools is not masking any ambiguous nucleotide using lowercase letters).
MAFFT provides the option `--preserve-case` to do this, an option that does not appear to be implemented for python's `Bio.Align.Applications.MafftCommandline`.
The suggested solution is to run MAFFT using `os.system` on temporary files and save the final aligned consensus in the correct format.